### PR TITLE
fix(docs): Correct match-path for FindHookSalt test command

### DIFF
--- a/foundry/exercises/counter.md
+++ b/foundry/exercises/counter.md
@@ -52,7 +52,7 @@ counts[key.toId()]["beforeSwap"]
 1. Find the value of `salt` needed to deploy the hooks contract at a valid address.
 
 ```shell
-forge test --match-path test/FindHookSalt.sol -vvv
+forge test --match-path test/FindHookSalt.test.sol -vvv
 ```
 
 2. Export the salt printed to your terminal from executing the command in the previous step.


### PR DESCRIPTION
This PR fixes a documentation bug in the CounterHook exercise (counter.md).

The forge test command in counter.md was referencing an incorrect filename, leading to "No tests match" errors.

Correction
Updated the path from test/FindHookSalt.sol to the correct file name: test/FindHookSalt.test.sol.