### PR TITLE
CurrencyLib: fix balanceOf(ETH) to return account.balance (not address(this).balance)

### DIFF
--- a/foundry/src/libraries/CurrencyLib.sol
+++ b/foundry/src/libraries/CurrencyLib.sol
@@ -4,9 +4,11 @@ pragma solidity 0.8.30;
 import {IERC20} from "../interfaces/IERC20.sol";
 
 library CurrencyLib {
-    function transferIn(address currency, address src, uint256 amount)
-        internal
-    {
+    function transferIn(
+        address currency,
+        address src,
+        uint256 amount
+    ) internal {
         if (currency == address(0)) {
             require(amount == msg.value, "msg.value != amount");
         } else {
@@ -14,24 +16,25 @@ library CurrencyLib {
         }
     }
 
-    function transferOut(address currency, address dst, uint256 amount)
-        internal
-    {
+    function transferOut(
+        address currency,
+        address dst,
+        uint256 amount
+    ) internal {
         if (currency == address(0)) {
-            (bool ok,) = dst.call{value: amount}("");
+            (bool ok, ) = dst.call{value: amount}("");
             require(ok, "send ETH failed");
         } else {
             IERC20(currency).transfer(dst, amount);
         }
     }
 
-    function balanceOf(address currency, address account)
-        internal
-        view
-        returns (uint256)
-    {
+    function balanceOf(
+        address currency,
+        address account
+    ) internal view returns (uint256) {
         if (currency == address(0)) {
-            return address(this).balance;
+            return account.balance;
         } else {
             return IERC20(currency).balanceOf(account);
         }


### PR DESCRIPTION
### Summary
In `src/libraries/CurrencyLib.sol`, the ETH branch of:
```solidity
function balanceOf(address currency, address account) internal view returns (uint256)
```

returns address(this).balance instead of the passed-in account’s balance.
This PR corrects the behavior to return account.balance.

### Rationale

The ERC-20 branch already queries IERC20(currency).balanceOf(account), i.e., it respects the account parameter.
Aligning the ETH branch with that semantics improves correctness and developer intuition.
Uniswap v4-core’s Currency semantics also treat ETH balance queries as “the queried account’s balance,” not the caller contract’s balance.

### Change
```solidity
 function balanceOf(address currency, address account)
     internal
     view
     returns (uint256)
 {
     if (currency == address(0)) {
-        return address(this).balance;
+        return account.balance;
     } else {
         return IERC20(currency).balanceOf(account);
     }
 }
```

### Impact

Fixes incorrect ETH balance reads where callers expect the target account’s balance.
Restores consistency between the ETH and ERC-20 branches.
No external API changes; this is a behavioral fix.
